### PR TITLE
Make FilesystemAdapter serializable 

### DIFF
--- a/src/FilesystemAdapter.php
+++ b/src/FilesystemAdapter.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\PsrCacheModule;
+
+use Serializable;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter as OriginAdapter;
+
+use function get_object_vars;
+use function serialize;
+use function unserialize;
+
+class FilesystemAdapter extends OriginAdapter implements Serializable
+{
+    /**
+     * @inheritDoc
+     */
+    public function serialize()
+    {
+        $data = get_object_vars($this);
+
+        return serialize($data);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function unserialize($data)
+    {
+        /** @var array<string, scalar|object> $data */
+        $data = unserialize($data);
+        foreach ($data as $name => $value) {
+            $this->$name = $value;
+        }
+    }
+}

--- a/src/LocalCacheProvider.php
+++ b/src/LocalCacheProvider.php
@@ -9,7 +9,6 @@ use Ray\PsrCacheModule\Annotation\CacheDir;
 use Ray\PsrCacheModule\Annotation\CacheNamespace;
 use Symfony\Component\Cache\Adapter\ApcuAdapter;
 use Symfony\Component\Cache\Adapter\ChainAdapter;
-use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 
 use function sys_get_temp_dir;
 

--- a/vendor-bin/tools/composer.lock
+++ b/vendor-bin/tools/composer.lock
@@ -1917,16 +1917,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.5",
+            "version": "9.5.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "89ff45ea9d70e35522fb6654a2ebc221158de276"
+                "reference": "fb9b8333f14e3dce976a60ef6a7e05c7c7ed8bfb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/89ff45ea9d70e35522fb6654a2ebc221158de276",
-                "reference": "89ff45ea9d70e35522fb6654a2ebc221158de276",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/fb9b8333f14e3dce976a60ef6a7e05c7c7ed8bfb",
+                "reference": "fb9b8333f14e3dce976a60ef6a7e05c7c7ed8bfb",
                 "shasum": ""
             },
             "require": {
@@ -1956,7 +1956,7 @@
                 "sebastian/global-state": "^5.0.1",
                 "sebastian/object-enumerator": "^4.0.3",
                 "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^2.3.2",
+                "sebastian/type": "^2.3.4",
                 "sebastian/version": "^3.0.2"
             },
             "require-dev": {
@@ -2004,7 +2004,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.5"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.6"
             },
             "funding": [
                 {
@@ -2016,7 +2016,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-06-05T04:49:07+00:00"
+            "time": "2021-06-23T05:14:38+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -3025,7 +3025,6 @@
                     "type": "github"
                 }
             ],
-            "abandoned": true,
             "time": "2020-09-28T06:45:17+00:00"
         },
         {
@@ -4647,5 +4646,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
Remove "Prevent destructors with side-effects from being unserialized".
@see https://symfony.com/blog/cve-2019-10912-prevent-destructors-with-side-effects-from-being-unserialized

This class should be used only in non-user-input.