### PR TITLE
Fix Memcached bind

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Ray\\PsrCacheModule\\": ["src/", "src-deprecated"]
+            "Ray\\PsrCacheModule\\": ["src/", "src-deprecated/"]
         }
     },
     "autoload-dev": {

--- a/src-deprecated/MemcachdAdapter.php
+++ b/src-deprecated/MemcachdAdapter.php
@@ -14,10 +14,7 @@ use Symfony\Component\Cache\Marshaller\MarshallerInterface;
 
 use function func_get_args;
 
-/**
- * @psalm-suppress PropertyNotSetInConstructor
- * @deprecated Use \Ray\PsrCacheModule\MemcachedAdapter instead
- */
+/** @deprecated Use \Ray\PsrCacheModule\MemcachedAdapter instead */
 class MemcachdAdapter extends OriginAdapter implements Serializable
 {
     use SerializableTrait;

--- a/src-deprecated/MemcachdAdapter.php
+++ b/src-deprecated/MemcachdAdapter.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\PsrCacheModule;
+
+use Memcached;
+use Ray\Di\Di\Named;
+use Ray\Di\ProviderInterface;
+use Ray\PsrCacheModule\Annotation\CacheNamespace;
+use Serializable;
+use Symfony\Component\Cache\Adapter\MemcachedAdapter as OriginAdapter;
+use Symfony\Component\Cache\Marshaller\MarshallerInterface;
+
+use function func_get_args;
+
+/**
+ * @psalm-suppress PropertyNotSetInConstructor
+ * @deprecated Use \Ray\PsrCacheModule\MemcachedAdapter instead
+ */
+class MemcachdAdapter extends OriginAdapter implements Serializable
+{
+    use SerializableTrait;
+
+    /**
+     * @param ProviderInterface<Memcached> $clientProvider
+     *
+     * @Named("memcached")
+     * @CacheNamespace("namespace")
+     */
+    #[CacheNamespace('namespace')]
+    #[Named('memcached')]
+    public function __construct(ProviderInterface $clientProvider, string $namespace = '', int $defaultLifetime = 0, ?MarshallerInterface $marshaller = null)
+    {
+        $this->args = func_get_args();
+
+        parent::__construct($clientProvider->get(), $namespace, $defaultLifetime, $marshaller);
+    }
+}

--- a/src/MemcachedAdapter.php
+++ b/src/MemcachedAdapter.php
@@ -15,7 +15,7 @@ use Symfony\Component\Cache\Marshaller\MarshallerInterface;
 use function func_get_args;
 
 /** @psalm-suppress PropertyNotSetInConstructor */
-class MemcachdAdapter extends OriginAdapter implements Serializable
+class MemcachedAdapter extends OriginAdapter implements Serializable
 {
     use SerializableTrait;
 

--- a/tests/MemcachedAdapterTest.php
+++ b/tests/MemcachedAdapterTest.php
@@ -15,11 +15,11 @@ use function unserialize;
 
 class MemcachedAdapterTest extends TestCase
 {
-    /** @return array{0:string, 1: MemcachdAdapter} */
+    /** @return array{0:string, 1: MemcachedAdapter} */
     public function testSerialize(): array
     {
         $provider = new MemcachedProvider([['127.0.0.1', '11211']]);
-        $adapter = new MemcachdAdapter($provider);
+        $adapter = new MemcachedAdapter($provider);
         $adapter->get('foo', static function (ItemInterface $item) {
             return 'foobar';
         });
@@ -34,19 +34,19 @@ class MemcachedAdapterTest extends TestCase
     }
 
     /**
-     * @param array{0:string, 1: MemcachdAdapter} $adapters
+     * @param array{0:string, 1: MemcachedAdapter} $adapters
      *
      * @depends testSerialize
      */
     public function testUnserialize(array $adapters): void
     {
-        $this->assertInstanceOf(MemcachdAdapter::class, $adapters[1]);
+        $this->assertInstanceOf(MemcachedAdapter::class, $adapters[1]);
         $this->assertSame('foobar', $adapters[1]->get('foo', static function (ItemInterface $item) {
             return '_no_serve_in_object';
         }));
 
         $adapter0 = unserialize($adapters[0]);
-        $this->assertInstanceOf(MemcachdAdapter::class, $adapter0);
+        $this->assertInstanceOf(MemcachedAdapter::class, $adapter0);
         $this->assertSame('foobar', $adapter0->get('foo', static function (ItemInterface $item) {
             return '_no_serve_in_serialize';
         }));
@@ -59,11 +59,11 @@ class MemcachedAdapterTest extends TestCase
             {
                 $this->install(new CacheNamespaceModule('a'));
                 $this->install(new CacheDirModule('/tmp/a'));
-                $this->bind(AbstractAdapter::class)->to(MemcachdAdapter::class);
+                $this->bind(AbstractAdapter::class)->to(MemcachedAdapter::class);
                 $this->install(new Psr6MemcachedModule('127.0.0.1:6379:1'));
             }
         });
         $adapter = $injector->getInstance(AbstractAdapter::class);
-        $this->assertInstanceOf(MemcachdAdapter::class, $adapter);
+        $this->assertInstanceOf(MemcachedAdapter::class, $adapter);
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Corrected the class name from `MemcachdAdapter` to `MemcachedAdapter` for consistency and clarity.
	- Updated autoload paths in `composer.json` for the namespace `Ray\\PsrCacheModule\\`.
	- Deprecated `MemcachdAdapter` class in `src-deprecated` with a recommendation to use `\Ray\PsrCacheModule\MemcachedAdapter`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->