### PR TITLE
Enable PHP 8.4 compat and bump symfony/cache v7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# Alerts only major updates for Packagist (Composer)
+#
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "composer" # Specify the correct package ecosystem for PHP
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*" # Ignore all dependencies for specific update types
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: "phpunit/phpunit"
+        update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,6 @@ updates:
       interval: "weekly"
     ignore:
       - dependency-name: "*" # Ignore all dependencies for specific update types
-        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+        update-types: ["version-update:semver-minor"]
       - dependency-name: "phpunit/phpunit"
         update-types: ["version-update:semver-major"]

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -9,4 +9,4 @@ jobs:
   cs:
     uses: ray-di/.github/.github/workflows/coding-standards.yml@v1
     with:
-      php_version: 8.2
+      php_version: 8.3

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -32,6 +32,7 @@ jobs:
           - '8.1'
           - '8.2'
           - '8.3'
+          - '8.4'
         dependencies:
           - lowest
           - highest

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -9,5 +9,5 @@ jobs:
   sa:
     uses: ray-di/.github/.github/workflows/static-analysis.yml@v1
     with:
-      php_version: 8.2
+      php_version: 8.3
       has_crc_config: true

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": "^7.3 || ^8.0",
         "psr/cache": "^1.0.1 || ^2.0 || ^3.0",
         "ray/di": "^2.13.2",
-        "symfony/cache": "^5.3.4 || ^6.0",
+        "symfony/cache": "^5.3.4 || ^6.0 || ^v7.1",
         "doctrine/annotations": "^1.13",
         "psr/simple-cache": "^1.0 || ^2.0 || ^3.0",
         "ray/aop": "^2.10.4"

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "psr/cache": "^1.0.1 || ^2.0 || ^3.0",
         "ray/di": "^2.13.2",
         "symfony/cache": "^5.3.4 || ^6.0 || ^v7.1",
-        "doctrine/annotations": "^1.13",
+        "doctrine/annotations": "^1.13 || ^2.0",
         "psr/simple-cache": "^1.0 || ^2.0 || ^3.0",
         "ray/aop": "^2.10.4"
     },

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": "^7.3 || ^8.0",
         "psr/cache": "^1.0.1 || ^2.0 || ^3.0",
         "ray/di": "^2.13.2",
-        "symfony/cache": "^5.3.4 || ^6.0 || ^v7.1",
+        "symfony/cache": "^5.3.4 || ^6.0 || ^7.1",
         "doctrine/annotations": "^1.13 || ^2.0",
         "psr/simple-cache": "^1.0 || ^2.0 || ^3.0",
         "ray/aop": "^2.10.4"


### PR DESCRIPTION
- Add dependabot
- Bump tool dependency
- Bump symfony/cache v7
- Bump doctrine/annotation v2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a configuration for managing Composer dependency updates, including weekly checks and an ignore list for specific updates.
  
- **Improvements**
	- Updated PHP version in coding standards and static analysis workflows to 8.3.
	- Added PHP version 8.4 to the continuous integration testing matrix.
	- Expanded compatibility for `symfony/cache` and `doctrine/annotations` dependencies in `composer.json`. 

These updates enhance dependency management and ensure compatibility with the latest PHP versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->