### PR TITLE
Fix rector-migrate.php to allow user-specified paths

### DIFF
--- a/rector-migrate.php
+++ b/rector-migrate.php
@@ -17,10 +17,6 @@ use Rector\Php80\ValueObject\AnnotationToAttribute;
  *   vendor/bin/rector process src --config=vendor/ray/psr-cache-module/rector-migrate.php
  */
 return RectorConfig::configure()
-    ->withPaths([
-        __DIR__ . '/src',
-        __DIR__ . '/tests',
-    ])
     ->withConfiguredRule(
         AnnotationToAttributeRector::class,
         [


### PR DESCRIPTION
## Summary

Fixed `rector-migrate.php` configuration to allow users to specify their own project paths via command line instead of hardcoded vendor paths.

## Problem

The previous configuration had `withPaths([__DIR__ . '/src', __DIR__ . '/tests'])` which pointed to:
- `vendor/ray/psr-cache-module/src`
- `vendor/ray/psr-cache-module/tests`

This was incorrect because users want to migrate **their own code**, not the vendor package code.

## Solution

Removed the `withPaths()` configuration entirely. Users now specify paths on the command line:

```bash
vendor/bin/rector process src --config=vendor/ray/psr-cache-module/rector-migrate.php --dry-run
vendor/bin/rector process src tests --config=vendor/ray/psr-cache-module/rector-migrate.php
```

## Changes

- Removed `withPaths()` from `rector-migrate.php`
- Updated usage documentation in file header remains correct

This follows the pattern from Ray.AuraSqlModule's rector-migrate.php.

## Summary by Sourcery

Remove hardcoded paths from rector-migrate.php so users can specify their own source and test directories via command-line arguments instead of defaulting to vendor package code

Bug Fixes:
- Prevent unintended migration of vendor code by eliminating withPaths configuration

Enhancements:
- Delegate path configuration entirely to CLI parameters rather than static config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code migration tool configuration to use default path processing instead of explicitly specified targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->