### PR TITLE
Remove legacy doctrine annotation comments from provider classes

### DIFF
--- a/src/MemcachedProvider.php
+++ b/src/MemcachedProvider.php
@@ -14,7 +14,6 @@ class MemcachedProvider implements ProviderInterface
     /**
      * @param array<array<string>> $servers
      *
-     * @MemcacheConfig("servers")
      * @see https://www.php.net/manual/en/memcached.addservers.php
      */
     #[MemcacheConfig('servers')]

--- a/src/RedisProvider.php
+++ b/src/RedisProvider.php
@@ -14,11 +14,7 @@ use function sprintf;
 /** @implements ProviderInterface<Redis> */
 class RedisProvider implements ProviderInterface
 {
-    /**
-     * @param list<string> $server
-     *
-     * @RedisConfig("server")
-     */
+    /** @param list<string> $server */
     #[RedisConfig('server')]
     public function __construct(private array $server)
     {


### PR DESCRIPTION
## Summary
Removes legacy doctrine annotation comments from provider classes to fix `AnnotationException` when using `koriym/attributes` with `DualReader`.

## Changes
- **src/RedisProvider.php**: Remove `@RedisConfig("server")` annotation comment
- **src/MemcachedProvider.php**: Remove `@MemcacheConfig("servers")` annotation comment

## Details
After migrating to PHP 8 attributes in version 1.5.0, legacy doctrine annotation comments remained in provider class docblocks. These cause `AnnotationException` when downstream packages using `koriym/attributes`'s `DualReader` attempt to parse them.

The issue occurs because:
1. Docblocks contain both legacy `@RedisConfig` comments and new `#[RedisConfig]` attributes
2. `DualReader` finds `@RedisConfig` and tries to process it as a doctrine annotation
3. The `RedisConfig` class no longer has `@Annotation` docblock (correctly removed during PHP 8 migration)
4. Doctrine's `AnnotationReader` throws `AnnotationException`

## What's Preserved
- PHP 8 attributes (`#[RedisConfig]`, `#[MemcacheConfig]`)
- Type hints (`@param`, `@return`, `@var`)
- Documentation comments (`@see`, `@throws`)

## Testing
- `composer cs-fix` applied successfully
- Code follows PSR-12 standards

Fixes #33

## Summary by Sourcery

Remove legacy Doctrine annotation comments from provider classes to prevent AnnotationException when using DualReader.

Bug Fixes:
- Remove leftover @RedisConfig annotation comment from RedisProvider.
- Remove leftover @MemcacheConfig annotation comment from MemcachedProvider.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor

* Consolidated configuration annotation declarations in provider classes, eliminating redundancy in how configurations are expressed without affecting functionality or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->