### PR TITLE
Move qualifier attributes from method-level to parameter-level

### DIFF
--- a/src/LocalCacheProvider.php
+++ b/src/LocalCacheProvider.php
@@ -22,10 +22,12 @@ final readonly class LocalCacheProvider implements ProviderInterface
 {
     private string $cacheDir;
 
-    #[CacheDir('cacheDir')]
-    #[CacheNamespace('namespace')]
-    public function __construct(string $cacheDir = '', private string $namespace = '')
-    {
+    public function __construct(
+        #[CacheDir]
+        string $cacheDir = '',
+        #[CacheNamespace]
+        private string $namespace = '',
+    ) {
         $this->cacheDir = $cacheDir ?: sys_get_temp_dir();
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,10 +1,3 @@
 <?php
 
 declare(strict_types=1);
-
-use Koriym\Attributes\AttributeReader;
-use Ray\ServiceLocator\ServiceLocator;
-
-if (PHP_MAJOR_VERSION >= 8) {
-    ServiceLocator::setReader(new AttributeReader());
-}


### PR DESCRIPTION
Method-level #[CacheDir] and #[CacheNamespace] attributes on the constructor were not resolved by Ray.Di, which only processes parameter-level attributes. This caused the cache directory to always fall back to sys_get_temp_dir() instead of using the bound CacheDir value.